### PR TITLE
Add `findingsRepo` field to contests

### DIFF
--- a/_data/contests/88mph.json
+++ b/_data/contests/88mph.json
@@ -6,5 +6,6 @@
   "sponsor": "88mph",
   "contestid": 8,
   "amount": "$45,000 USDC",
-  "repo": "https://github.com/code-423n4/2021-05-88mph"
+  "repo": "https://github.com/code-423n4/2021-05-88mph",
+  "findingsRepo": "https://github.com/code-423n4/2021-05-88mph-findings"
 }

--- a/_data/contests/based.json
+++ b/_data/contests/based.json
@@ -7,5 +7,6 @@
   "contestid": 6,
   "amount": "$30,000 USDC",
   "repo": "https://github.com/code-423n4/basedloans",
+  "findingsRepo": "https://github.com/code-423n4/2021-04-basedloans-findings",
   "hide": true
 }

--- a/_data/contests/elasticdao.json
+++ b/_data/contests/elasticdao.json
@@ -5,5 +5,7 @@
   "title": "ElasticDAO contest",
   "sponsor": "ElasticDAO",
   "contestid": 2,
-  "hide": true
+  "hide": true,
+  "repo": "https://github.com/code-423n4/2021-03-elasticdao",
+  "findingsRepo": "https://github.com/code-423n4/2021-03-elasticdao-findings"
 }

--- a/_data/contests/fairside.json
+++ b/_data/contests/fairside.json
@@ -6,5 +6,6 @@
   "sponsor": "FairSide",
   "contestid": 10,
   "amount": "$40,000 USDC",
-  "repo": "https://github.com/code-423n4/2021-05-fairside"
+  "repo": "https://github.com/code-423n4/2021-05-fairside",
+  "findingsRepo": "https://github.com/code-423n4/2021-05-fairside-findings"
 }

--- a/_data/contests/maplefinance.json
+++ b/_data/contests/maplefinance.json
@@ -7,5 +7,6 @@
   "contestid": 4,
   "amount": "$100,000 USDC",
   "repo": "https://github.com/code-423n4/2021-04-maple",
+  "findingsRepo": "https://github.com/code-423n4/2021-04-maple-findings",
   "hide": true
 }

--- a/_data/contests/marginswap.json
+++ b/_data/contests/marginswap.json
@@ -6,5 +6,7 @@
   "sponsor": "Marginswap",
   "contestid": 3,
   "amount": "$50,000 USDC",
-  "hide": true
+  "hide": true,
+  "repo": "https://github.com/code-423n4/2021-04-marginswap",
+  "findingsRepo": "https://github.com/code-423n4/2021-04-marginswap-findings"
 }

--- a/_data/contests/meebits.json
+++ b/_data/contests/meebits.json
@@ -7,5 +7,6 @@
   "contestid": 6,
   "amount": "$50,000 USDC",
   "repo": "https://github.com/code-423n4/2021-04-redacted",
+  "findingsRepo": "https://github.com/code-423n4/2021-04-meebits-findings",
   "hide": true
 }

--- a/_data/contests/nftx.json
+++ b/_data/contests/nftx.json
@@ -7,5 +7,6 @@
   "contestid": 8,
   "amount": "$66,000 USDC",
   "repo": "https://github.com/code-423n4/2021-05-nftx",
+  "findingsRepo": "https://github.com/code-423n4/2021-05-nftx-findings",
   "hide": true
 }

--- a/_data/contests/slingshot.json
+++ b/_data/contests/slingshot.json
@@ -5,5 +5,7 @@
   "title": "Slingshot Finance contest",
   "sponsor": "Slingshot Finance",
   "contestid": 1,
-  "hide": true
+  "hide": true,
+  "repo": "https://github.com/code-423n4/2021-02-slingshot",
+  "findingsRepo": "https://github.com/code-423n4/2021-02-slingshot-findings"
 }

--- a/_data/contests/vaderprotocol.json
+++ b/_data/contests/vaderprotocol.json
@@ -7,5 +7,6 @@
   "contestid": 5,
   "amount": "27 ETH + 1000 VETH",
   "repo": "https://github.com/code-423n4/2021-04-vader",
+  "findingsRepo": "https://github.com/code-423n4/2021-04-vader-findings",
   "hide": true
 }

--- a/_data/contests/visor.json
+++ b/_data/contests/visor.json
@@ -6,5 +6,6 @@
   "sponsor": "Visor",
   "contestid": 7,
   "amount": "$60,000 USDC",
-  "repo": "https://github.com/code-423n4/2021-05-visorfinance"
+  "repo": "https://github.com/code-423n4/2021-05-visorfinance",
+  "findingsRepo": "https://github.com/code-423n4/2021-05-visorfinance-findings"
 }

--- a/schema/ContestsJson.js
+++ b/schema/ContestsJson.js
@@ -6,6 +6,7 @@ type ContestsJson implements Node {
   amount:         String
   details:        String
   repo:           String
+  findingsRepo:   String
   start_time:     Date @dateformat
   end_time:       Date @dateformat
   wardens:        [ HandlesJson ] @link(by: "name", from: "people")

--- a/src/layouts/ReportForm.js
+++ b/src/layouts/ReportForm.js
@@ -6,7 +6,7 @@ const ReportForm = (props) => {
   return (
     <div>
       <Form
-        repoUrl={props.data.contestsJson.repo}
+        repoUrl={props.data.contestsJson.findingsRepo}
         contest={props.data.contestsJson.title}
         sponsor={props.data.contestsJson.sponsor.name}
       />
@@ -23,7 +23,7 @@ export const pageQuery = graphql`
       contestid
       start_time
       end_time
-      repo
+      findingsRepo
       sponsor {
         name
       }


### PR DESCRIPTION
This adds a new `findingsRepo` field to contests. I know typically they're in the same format as the normal repo, but I don't want to leave that up to chance.