### PR TITLE
Fix handle PR link on light scheme

### DIFF
--- a/src/components/reporter/widgets/WardenField.js
+++ b/src/components/reporter/widgets/WardenField.js
@@ -38,11 +38,12 @@ const WardenField = ({ label, helptext, options, onChange, fieldState }) => {
         className={styles.ReactSelect}
         classNamePrefix="react-select"
       />
-      <p>
+      <p className={baseStyles.Help}>
         <small>
-          Don't see your handle here? Submit a pull request{" "}
-          <a href="https://github.com/code-423n4/code423n4.com">here</a> to
-          register.
+          Don't see your handle here?{" "}
+          <a href="https://github.com/code-423n4/code423n4.com">
+            Submit a pull request here to register.
+          </a>
         </small>
       </p>
     </div>

--- a/src/components/reporter/widgets/Widgets.module.scss
+++ b/src/components/reporter/widgets/Widgets.module.scss
@@ -14,6 +14,15 @@
 .Help {
   color: inherit;
   font-size: 13px;
+
+  & a {
+    color: inherit;
+    text-decoration: underline;
+
+    &:hover {
+      border-bottom: none;
+    }
+  }
 }
 
 .Control {


### PR DESCRIPTION
On light color schemes, the help text on the handle select field isn't visible. This PR fixes that, and makes the entire sentence clickable.