### PR TITLE
Remove .reverse() and change to ASC time sort

### DIFF
--- a/src/components/ContestList.js
+++ b/src/components/ContestList.js
@@ -4,7 +4,7 @@ import Contest from "./Contest";
 const ContestList = ({ contests }) => {
   return (
     <>
-      {contests.reverse().map((contest) => (
+      {contests.map((contest) => (
         <Contest contest={contest} key={contest.node.id} />
       ))}
     </>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -36,7 +36,7 @@ export const query = graphql`
   query {
     contests: allContestsCsv(
       filter: { hide: { ne: true } }
-      sort: { fields: start_time, order: DESC }
+      sort: { fields: start_time, order: ASC }
     ) {
       edges {
         node {


### PR DESCRIPTION
# Overview

I'm pretty sure this was a cache issue. The `DESC` order was actually _not_ the order we wanted, which is why we'd reverse it. But upon a page change it'd grab the cached, reversed `DESC` data and then reverse it again.

This just grabs the filtered, `ASC` ordered data. 