### PR TITLE
Fixed formatting in judging-criteria.md

### DIFF
--- a/_content/judging-criteria.md
+++ b/_content/judging-criteria.md
@@ -91,8 +91,7 @@ What resources and opportunities are required for this group of threat agents to
 - Full access or expensive resources required **(0)**
 - Special access or resources required **(4)**
 - Some access or resources required **(7)**
-- No access or re## 5.7. Duplicate Submissions
-  Should the same bug be submitted by multiple Wardens, Judges have the discretion to place these bugs into the same bucket, in which case, the award will be shared among those who submitted.
+- No access or resources required **(9)**
 
 How large is this group of threat agents?
 


### PR DESCRIPTION
Line 94 displayed duplicate text from lines 15-17, rather than iterating the highest scale of resource intensity required for the hack. 

Duplicate text in question ironically referred to bounty sharing between duplicate bug submissions by Wardens. If Warden submissions are graded by formatting, how much is my bounty for fixing a bug off-chain + on code423n4 website? ;)