### PR TITLE
Update warden registration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,9 @@
 # Register as a warden
 
-Registering as a warden allows you to be listed on our [leaderboard](https://code423n4.com/leaderboard). It's possible to do this step asynchronously from submitting a bug for a contest.
+Registering as a warden allows you to be listed on our [leaderboard](https://code423n4.com/leaderboard). You'll need to register your handle in order to submit a bug for a contest.
 
-**Fork this repo and create a PR:**
-
-1. Add a JSON file for yourself at [\_data/handles](https://github.com/code-423n4/code423n4.com/tree/main/_data/handles), and an avatar at [\_data/handles/avatars](https://github.com/code-423n4/code423n4.com/tree/main/_data/handles/avatars):
-
-```json
-{
-  "handle": "maurelian",
-  "image": "./avatars/maurelian.jpg",
-  "link": "https://twitter.com/maurelian_"
-}
-```
-
-2. If you're registering a team, add the individual handles of the team members like so:
-
-```json
-{
-  "image": "",
-  "handle": "pocotiempo",
-  "members": ["maurelian", "0xRajeev", "mariano"]
-}
-```
+1. Visit our [warden registration page](https://code423n4.com/warden-registration/) and submit your details. A C4 team member will then approve your handle, allowing you to participate in contests.
+2. Join our [Discord](https://discord.gg/code4rena). This step is optional, but highly recommended. We suggest you use the same name in Discord as your registered handle; this will allow us to notify you when you receive an award from a contest.
 
 The handle your issues are submitted under will determine where awards will go, so it's possible to be part of a team on some contests and _also_ compete as an individual on other contests.
 


### PR DESCRIPTION
This PR updates our README with instructions on how to register, including a note about making sure their Discord name matches their handle.