### PR TITLE
Solo Findings on Contest Leaderboard

### DIFF
--- a/src/templates/ContestLayout.js
+++ b/src/templates/ContestLayout.js
@@ -228,6 +228,7 @@ export const query = graphql`
         finding
         awardUSD
         risk
+        split
         handle {
           handle
           image {


### PR DESCRIPTION
The split field wasn't included in the GraphQL data used to build the contest leaderboard.