### PR TITLE
Fixes linesOfCode regex, and removes global behaviour

### DIFF
--- a/src/components/reporter/SubmitFindings.js
+++ b/src/components/reporter/SubmitFindings.js
@@ -110,7 +110,7 @@ const SubmitFindings = ({ wardensList, sponsor, contest, repo }) => {
       hasErrors = true;
     }
 
-    const regex = new RegExp("#L", "g");
+    const regex = new RegExp("#L[0-9]+(-L[0-9]+)?$");
     const hasInvalidLinks = state.linesOfCode.some((line) => {
       return !regex.test(line.value);
     });


### PR DESCRIPTION
The RegExp object has a nuance when used with the `"g"` flag. It can't be re-used across multiple input strings, as it keeps an index counter of the last occurence.

here's a sample that fails:
```
var re = /^a/g;
console.log(re.test("ab")); // true, lastIndex was 0
console.log(re.test("ab")); // false, lastIndex was 1 
```

Since we're parsing multiple lines of code, this behaviour makes the regex fail for all but the first line.

In addition to removing the flag, I also took the chance to improve the regex to catch only correct line and line range hashes (i.e.: match the numbers as well)