### PR TITLE
Rebrandino fixes

### DIFF
--- a/src/components/ContestTile.js
+++ b/src/components/ContestTile.js
@@ -46,7 +46,7 @@ const ContestTile = ({ contest, updateContestStatus, user, reduced }) => {
   return (
     <article className={"contest-tile " + t.contestStatus + " " + reduced}>
       <div className="contest-tile__top">
-        <header class="contest-tile__content">
+        <header className="contest-tile__content">
           <div className="contest-tile__logo">
             <SponsorLink sponsor={sponsor} />
           </div>

--- a/src/components/LeaderboardTable.js
+++ b/src/components/LeaderboardTable.js
@@ -163,12 +163,12 @@ const LeaderboardTable = ({ results, isLoading, reduced }) => {
             );
           })}
         </tbody>
-      ) : !isLoading ? (
+      ) : isLoading ? (
         <tbody>
           {/* TODO - finish animating this */}
           <tr>
             <td colSpan="9" className="center">
-              <h3 className="skeleton-loader">Fetching results...</h3>
+              <h3 className="leaderboard__loading">Fetching results...</h3>
             </td>
           </tr>
         </tbody>

--- a/src/components/LeaderboardTableReduced.js
+++ b/src/components/LeaderboardTableReduced.js
@@ -142,8 +142,8 @@ const LeaderboardTableReduced = ({ results, isLoading, reduced }) => {
               );
             })}
           </div>
-        ) : !isLoading ? (
-          <ul className="leaderboard__error">
+        ) : isLoading ? (
+          <ul className="leaderboard__loading">
             <li>Fetching results...</li>
           </ul>
         ) : (

--- a/src/components/ReportTile.js
+++ b/src/components/ReportTile.js
@@ -35,10 +35,10 @@ const ReportTile = ({ report }) => {
                   className="svg"
                   points="10 1 4 7 4 31 28 31 28 1 10 1"
                 />
-                <polyline class="cls-1" points="10 1 10 7 4 7" />
-                <line class="cls-1" x1="8" x2="24" y1="15" y2="15" />
-                <line class="cls-1" x1="8" x2="24" y1="20" y2="20" />
-                <line class="cls-1" x1="8" x2="24" y1="25" y2="25" />
+                <polyline className="cls-1" points="10 1 10 7 4 7" />
+                <line className="cls-1" x1="8" x2="24" y1="15" y2="15" />
+                <line className="cls-1" x1="8" x2="24" y1="20" y2="20" />
+                <line className="cls-1" x1="8" x2="24" y1="25" y2="25" />
               </g>
             </svg>
             {format(new Date(report.date), "d MMM yyyy")}

--- a/src/components/SecondaryNavItem.tsx
+++ b/src/components/SecondaryNavItem.tsx
@@ -11,7 +11,8 @@ export default function SecondaryNavItem(props): JSX.Element {
   const { to, text, active, children } = props;
   return (
     <button
-      {...props}
+    {...props}
+    active={active ? "true" : "false"}
       className={(active ? "active " : "") + "secondary-nav__item"}
     >
       {children ? children : text ? text : "Link"}

--- a/src/components/Testimonials.js
+++ b/src/components/Testimonials.js
@@ -10,7 +10,7 @@ const testimonials = [
   {
     quote:
       "One of the things I enjoy most about competing on @code4rena is getting to read lots of code and see new techniques in the wild.",
-    author: "@eth_call",
+    author: "Horsefacts",
     authorTitle: "",
     authorLink: "https://twitter.com/eth_call/status/1621940992411574284",
     viewMode: "warden",
@@ -18,7 +18,7 @@ const testimonials = [
   {
     quote:
       "After grinding for 14 months I finally reached my goal of being the first to cross 1M$ on the @code4rena leaderboard. Thanks to everyone involved, this has been very fun, lucrative, and I learned a lot by seeing other wardens' vulnerabilities that I missed.",
-    author: "@Cmichelio",
+    author: "Cmichel",
     authorTitle: "",
     authorLink: "https://twitter.com/cmichelio/status/1521241247159140355",
     viewMode: "warden",
@@ -26,7 +26,7 @@ const testimonials = [
   {
     quote:
       "Just went through the latest @code4rena audit report of the @blur_io exchange. This report is a great example of why audits are so important - wardens were able to discover a high risk exploit that would've allowed sellers to steal funds from buyers.",
-    author: "@0xCygaar",
+    author: "cygaar",
     authorTitle: "",
     authorLink: "https://twitter.com/0xCygaar/status/1601065454771924992",
     viewMode: "warden",
@@ -50,9 +50,9 @@ const testimonials = [
   },
   {
     quote: "C4 wardens > any single audit shop IMO",
-    author: "Benjamin Hughes",
+    author: "@_benjaminhughes",
     authorTitle: "",
-    authorLink: "",
+    authorLink: "https://twitter.com/_benjaminhughes",
     viewMode: "sponsor",
   },
   {

--- a/src/components/TrustBar.js
+++ b/src/components/TrustBar.js
@@ -161,6 +161,7 @@ const TrustBar = () => (
             key={logo.link}
             target="_blank"
             rel="noreferrer"
+            className="trustbar__logo"
           >
             <img src={logo.imgSrc} alt={logo.alt} />
           </a>

--- a/src/components/content/Footer.js
+++ b/src/components/content/Footer.js
@@ -5,7 +5,7 @@ const Footer = () => {
   return (
     <footer className="footer limited-width">
       <ul className="footer__items">
-        <li className="footer__item">An open organization</li>
+        <li className="footer__item">AN OPEN ORGANIZATION</li>
         <li className="footer__item">
           <a
             href="https://twitter.com/code4rena"
@@ -13,7 +13,7 @@ const Footer = () => {
             rel="noreferrer"
             aria-label="Twitter (Opens in new Window)"
           >
-            Twitter
+            TWITTER
           </a>
         </li>
         <li className="footer__item">
@@ -23,7 +23,7 @@ const Footer = () => {
             rel="noreferrer"
             aria-label="Discord (Opens in new Window)"
           >
-            Discord
+            DISCORD
           </a>
         </li>
         <li className="footer__item">
@@ -33,7 +33,7 @@ const Footer = () => {
             rel="noreferrer"
             aria-label="GitHub (Opens in new Window)"
           >
-            GitHub
+            GITHUB
           </a>
         </li>
         <li className="footer__item">
@@ -43,11 +43,11 @@ const Footer = () => {
             rel="noreferrer"
             aria-label="Medium (Opens in new Window)"
           >
-            Medium
+            MEDIUM
           </a>
         </li>
         <li className="footer__item">
-          <Link to="/newsletter-signup">Newsletter</Link>
+          <Link to="/newsletter-signup">NEWSLETTER</Link>
         </li>
         <li className="footer__item">
           <span className="eth-address">

--- a/src/components/content/Footer.js
+++ b/src/components/content/Footer.js
@@ -52,7 +52,7 @@ const Footer = () => {
         <li className="footer__item">
           <span className="eth-address">
             <a href="https://etherscan.io/address/0xC2BC2F890067C511215F9463A064221577A53E10">
-              0xC2bc2F890067C511215f9463a064221577a53E10
+              code4rena.eth
             </a>
           </span>
         </li>

--- a/src/components/content/Pizzazz.js
+++ b/src/components/content/Pizzazz.js
@@ -50,16 +50,6 @@ const Pizzazz = () => {
 
       updateSize();
       window.addEventListener("resize", updateSize, false);
-      document.addEventListener("mousemove", (e) => {
-        const v = new THREE.Vector3();
-        camera.getWorldDirection(v);
-        v.normalize();
-        mousePlane.normal = v;
-        mouse.x = (e.clientX / width) * 2 - 1;
-        mouse.y = -(e.clientY / height) * 2 + 1;
-        raycaster.setFromCamera(mouse, camera);
-        raycaster.ray.intersectPlane(mousePlane, mousePosition);
-      });
 
       initScene();
       animate();

--- a/src/components/content/Pizzazz.js
+++ b/src/components/content/Pizzazz.js
@@ -34,9 +34,6 @@ const Pizzazz = () => {
     let plane;
     const simplex = new SimplexNoise();
     const mouse = new THREE.Vector2();
-    const mousePlane = new THREE.Plane(new THREE.Vector3(0, 0, 1), 0);
-    const mousePosition = new THREE.Vector3();
-    const raycaster = new THREE.Raycaster();
     init();
 
     function init() {
@@ -64,7 +61,7 @@ const Pizzazz = () => {
         side: THREE.DoubleSide,
       });
 
-      let geo = new THREE.PlaneBufferGeometry(
+      let geo = new THREE.PlaneGeometry(
         wWidth,
         wHeight,
         wWidth / 2,

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -21,7 +21,7 @@ export default function SiteIndex({ data }) {
   // @todo: implement global state management instead of props drilling
   const [contestStatusChanges, updateContestStatusChanges] = useState(0);
   const [filteredContests, setFilteredContest] = useState(null);
-  const [viewMode, setViewMode] = useState("warden"); // warden | sponsor
+  const [viewMode, setViewMode] = useState("sponsor"); // warden | sponsor
   const contests = data.contests.edges;
 
   const updateContestStatus = useCallback(() => {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -23,6 +23,14 @@ export default function SiteIndex({ data }) {
   const [filteredContests, setFilteredContest] = useState(null);
   const [viewMode, setViewMode] = useState("sponsor"); // warden | sponsor
   const contests = data.contests.edges;
+  useEffect(() => {
+    if (window.location.href.includes("#warden")) {
+      setViewMode("warden");
+    }
+    if (window.location.href.includes("#sponsor")) {
+      setViewMode("sponsor");
+    }
+  }, [])
 
   const updateContestStatus = useCallback(() => {
     updateContestStatusChanges(contestStatusChanges + 1);

--- a/src/styles/components/footer.scss
+++ b/src/styles/components/footer.scss
@@ -44,7 +44,7 @@
   }
 
   &::after {
-    content: "❯";
+    content: "|";
     margin: $spacing__s;
     color: $color__n-60;
 

--- a/src/styles/pages/home/top-names.scss
+++ b/src/styles/pages/home/top-names.scss
@@ -57,7 +57,7 @@ a.hero__top-auditor-name {
     @include accessible-animation {
       transition: $transition__base;
     }
-    background: $color__blurple-80;
+    background: $color__blurple-60;
     color: $color__white;
 
     .hero__top-auditor-link-arrow {

--- a/src/styles/pages/home/trustbar.scss
+++ b/src/styles/pages/home/trustbar.scss
@@ -9,13 +9,38 @@
   }
 }
 
+// .trustbar__logos {
+//   margin-top: $spacing__m;
+//   margin-bottom: $spacing__s;
+// }
+
+// .trustbar__logos a {
+//   display: inline-block;
+// }
+
+// .trustbar__logos img {
+//   height: 30px;
+//   max-width: 100px;
+//   padding: 2px;
+//   opacity: 0.7;
+//   display: inline-block;
+//   margin: $spacing__m $spacing__m 0 0;
+// }
+
 .trustbar__logos {
-  margin-top: $spacing__m;
-  margin-bottom: $spacing__s;
+  margin: $spacing__xl 0 0;
+  padding: 0;
+  list-style: none;
 }
 
 .trustbar__logos a {
+  margin: 0 $spacing__xs $spacing__xs 0;
   display: inline-block;
+
+  @include breakpoint("s") {
+    font-size: $headline-font-size__xxs;
+    margin: 0 $spacing__s $spacing__s 0;
+  }
 }
 
 .trustbar__logos img {
@@ -24,5 +49,25 @@
   padding: 2px;
   opacity: 0.7;
   display: inline-block;
-  margin: $spacing__m $spacing__m 0 0;
+}
+.trustbar__logo {
+  padding: calc($spacing__s) calc($spacing__m - 5px);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: $color__n-80;
+  border: 2px solid transparent;
+  border-radius: $border-radius__m;
+  color: $color__n-5;
+  &:hover {
+    @include accessible-animation {
+      transition: $transition__base;
+    }
+    background: $color__blurple-60;
+    color: $color__white;
+
+    .hero__top-auditor-link-arrow {
+      border-color: rgba($color__white, 0.2);
+    }
+  }
 }

--- a/src/styles/pages/leaderboard/leaderboard.scss
+++ b/src/styles/pages/leaderboard/leaderboard.scss
@@ -167,6 +167,12 @@ $avatar-size: 25px;
   text-align: center;
 }
 
+.leaderboard__loading {
+  text-align: center;
+  font-size: $headline-font-size__s;
+  margin-top: $spacing__m;
+}
+
 .leaderboard-handle,
 .leaderboard-handle a,
 .leaderboard-handle .leaderboard-handle__team {


### PR DESCRIPTION
- [x] remove mouse-responsive animation in pizzazz
- [x] footer - replace > with |
- [x] footer - code4rena.eth instead of wallet
- [x] Hover button bug in top auditors (jalapeño is blue) 
- [x] make sponsors the default view
- [x] create links for code4rena.com/#wardens, and #sponsors
- [x] quotes section - rename people with their warden names
- [x] keycap in the footer
- [x] put sponsor logos in boxes like auditors
- [x] leaderboard - change the text that shows to loading text. Style that also. 