### PR TITLE
fix: #11487 - Warden Application | Username hint-text out of date

### DIFF
--- a/src/components/RegistrationForm.tsx
+++ b/src/components/RegistrationForm.tsx
@@ -90,7 +90,7 @@ export default function RegistrationForm({ handles }) {
 
   // global variables
   const avatarInputRef = useRef<HTMLInputElement>();
-  const discordUsernameRegex = new RegExp(/.*#[0-9]{4}/, "g");
+  const discordUsernameRegex = new RegExp(/[a-z0-9-.]*/, "g");
 
   const updateErrorMessage = (
     message: string | React.ReactNode | undefined
@@ -373,7 +373,7 @@ export default function RegistrationForm({ handles }) {
       const validationErrors: (string | React.ReactNode)[] = [];
       if (!isValidDiscord) {
         validationErrors.push(
-          "Make sure you enter your discord username, and not your server nickname. It should end with '#' followed by 4 digits."
+          "Make sure you enter your discord username in lowercase, and not your server nickname or display name."
         );
       }
       return validationErrors;

--- a/src/components/RegistrationFormCommonFields.tsx
+++ b/src/components/RegistrationFormCommonFields.tsx
@@ -74,7 +74,7 @@ export default function RegistrationFormCommonFields({
         name="discordUsername"
         aria-describedby={"discordUsername--error"}
         helpText="Used in case we need to contact you about your submissions or winnings."
-        placeholder="Warden#1234"
+        placeholder="warden123"
         value={discordUsername}
         handleChange={handleChange}
         validator={discordUsernameValidator}


### PR DESCRIPTION
- [x] Updated discord username regex
- [x] Updated discord username hint message

[Discord username help](https://support.discord.com/hc/en-us/articles/12620128861463)

I have forced lowercase username as per documentation. Let me know if we need to allow uppercase as well.