### PR TITLE
Register bot sstan

### DIFF
--- a/_data/bots/sstan.json
+++ b/_data/bots/sstan.json
@@ -1,0 +1,17 @@
+{
+  "handle": "sstan",
+  "crew": [
+    "Osiris",
+    "0x00face"
+  ],
+  "paymentAddresses": [
+    {
+      "chain": "polygon",
+      "address": "0xc9808944047D1fF1899d8d0a3f42fABBD9E895EA"
+    },
+    {
+      "chain": "ethereum",
+      "address": "0xc9808944047D1fF1899d8d0a3f42fABBD9E895EA"
+    }
+  ]
+}


### PR DESCRIPTION
Registration for bot sstan submitted by Osiris.

Description:
`sstan` is a static analysis bot that uses ast analysis to identify patterns. We use `solang-parser` and a closed source analyzer to generate findings. Some patterns were inspired by `solstat`, but the core architecture is completely different than the approach taken by `solstat`

@0xOsiris