### PR TITLE
Register bot 4n0nx

### DIFF
--- a/_data/bots/4n0nx.json
+++ b/_data/bots/4n0nx.json
@@ -1,0 +1,16 @@
+{
+  "handle": "4n0nx",
+  "crew": [
+    "phenom80"
+  ],
+  "paymentAddresses": [
+    {
+      "chain": "polygon",
+      "address": "0x60075791A0ccC5B87c13063b349977CEBdb83347"
+    },
+    {
+      "chain": "ethereum",
+      "address": "0x60075791A0ccC5B87c13063b349977CEBdb83347"
+    }
+  ]
+}


### PR DESCRIPTION
Registration for bot 4n0nx submitted by phenom80.

Description:
# Report


## Gas Optimizations


| |Issue|Instances|
|-|:-|:-:|
| [GAS-1](#GAS-1) | Use assembly to emit events, in order to save gas | 102842 |
| [GAS-2](#GAS-2) | Use assembly for small keccak256 hashes, in order to save gas | 102842 |
| [GAS-3](#GAS-3) | Avoid fetching a low-level call's return data by using assembly | 102842 |
| [GAS-4](#GAS-4) | Using bools for storage incurs overhead | 102842 |
| [GAS-5](#GAS-5) | Avoid updating storage when the value hasn't changed | 102842 |
| [GAS-6](#GAS-6) | Using bools for storage incurs overhead | 1 |
| [GAS-7](#GAS-7) | Using bools for storage incurs overhead | 102842 |
| [GAS-8](#GAS-8) | Cache array length outside of loop | 3 |
| [GAS-9](#GAS-9) | State variables should be cached in stack variables | 70 |
| [GAS-10](#GAS-10) | For Operations that will not overflow, you could use unchecked | 245 |
| [GAS-11](#GAS-11) | Constructors can be marked payable | 102842 |
| [GAS-12](#GAS-12) | Events should be emitted outside of loops | 102842 |
| [GAS-13](#GAS-13) | Functions guaranteed to revert when called by normal users can be marked payable | 102842 |
| [GAS-14](#GAS-14) | State variables only set in the constructor should be declared immutable | 4 |
| [GAS-15](#GAS-15) | Don't initialize variables with default value | 11 |
| [GAS-16](#GAS-16) | Inline internal functions to save gas | 102842 |
| [GAS-17](#GAS-17) | Avoid updating storage when the value hasnt changed | 102842 |
| [GAS-18](#GAS-18) | Optimize names to save gas | 102842 |
| [GAS-19](#GAS-19) | Functions guaranteed to revert when called by normal users can be marked `payable` | 15 |
| [GAS-20](#GAS-20) | Functions guaranteed to revert when called by normal users can be marked payable | 102842 |
| [GAS-21](#GAS-21) | `++i` costs less gas than `i++`, especially when it's used in `for`-loops (`--i`/`i--` too) | 12 |
| [GAS-22](#GAS-22) | Using `private` rather than `public` for constants, saves gas | 2 |
| [GAS-23](#GAS-23) | Use shift Right/Left instead of division/multiplication if possible | 2 |
| [GAS-24](#GAS-24) | State variable read in a loop | 102842 |
| [GAS-25](#GAS-25) | Using storage instead of memory for structs/arrays saves gas | 35 |
| [GAS-26](#GAS-26) | Use uint256(1)/uint256(2) instead of true/false to save gas for changes | 102842 |
| [GAS-27](#GAS-27) | unchecked {} can be used on the division of two uints to save gas | 102842 |
| [GAS-28](#GAS-28) | Use != 0 instead of > 0 for unsigned integer comparison | 43 |
| [GAS-29](#GAS-29) | <x> += <y> costs more gas than <x> = <x> + <y> for state variables | 102842 |
| [GAS-30](#GAS-30) | Use assembly to emit events, in order to save gas | 102842 |
| [GAS-31](#GAS-31) | Using calldata instead of memory for read-only arguments in external functions saves gas | 102842 |
| [GAS-32](#GAS-32) | Use local variables for emitting | 102842 |
| [GAS-33](#GAS-33) | Use uint256(1)/uint256(2) instead of true/false to save gas for changes | 102842 |
### <a name="GAS-1"></a>[GAS-1] Use assembly to emit events, in order to save gas

#### Impact:
Using the scratch space for event arguments (two words or fewer) will save gas over needing Solidity's full ABI memory expansion used for emitting events normally.


@https://github.com/MR-Abbasnejad